### PR TITLE
Improve testing portability

### DIFF
--- a/tasks/proxy.yml
+++ b/tasks/proxy.yml
@@ -22,6 +22,9 @@
     - "{{ docker_registry_ssl_crt_dest }}"
     - "{{ docker_registry_ssl_key_dest }}"
 
+- assert: { that: docker_registry_ssl_crt_src is defined }
+- assert: { that: docker_registry_ssl_key_src is defined }
+
 - name: proxy | copy SSL cert and key
   copy:
     src: "{{ item.src }}"

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,6 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+if (ARGV & %w(up provision)).any?
+  exit 1 unless system('ansible-galaxy install -f -r requirements.yml -p ./roles')
+end
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
@@ -22,6 +26,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     machine.vm.provision "ansible" do |ansible|
       ansible.verbose = true
       ansible.playbook = "test.yml"
+      ansible.extra_vars = {
+          role_name: Dir.pwd.split('/')[-2]
+        }
     end
   end
 end

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+roles_path = ./roles:../../
+
+[ssh_connection]
+pipelining = true

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,7 +3,7 @@
   sudo: yes
 
   roles:
-  - role: '../..'
+  - role: "{{ role_name }}"
     docker_registry_http_host: localhost
     docker_registry_htpasswd_entries:
       - { user: root, pass: password }


### PR DESCRIPTION
- Update the Vagrantfile to install required roles within an isolated
  folder for testing.
- Determine the folder name the role is sitting in and use that as the
  role name.
- Add an assertion task to make sure the SSL cert/key has been defined
